### PR TITLE
Use a single project for all variants

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,3 @@
 rootProject.name = "micronaut-benchmark"
 include("test-case")
 include("load-generator-gatling")
-include("test-case-tcnative")

--- a/test-case/build.gradle.kts
+++ b/test-case/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
+
 plugins {
     id("java")
     id("io.micronaut.application") version "3.7.0"
@@ -21,6 +24,18 @@ application {
     mainClass.set("org.example.Main")
 }
 
+val tcnative by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = false
+}
+
+val tcnativeImageClasspath by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    extendsFrom(configurations.nativeImageClasspath.get())
+    extendsFrom(tcnative)
+}
+
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
     implementation("io.micronaut:micronaut-http-client")
@@ -29,8 +44,41 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+
+    tcnative("io.netty:netty-tcnative-boringssl-static:2.0.46.Final")
 }
 
 tasks.getByName<Test>("test") {
     useJUnitPlatform()
+}
+
+graalvmNative {
+    binaries {
+        create("tcnative") {
+            mainClass.set(application.mainClass)
+            classpath(tcnativeImageClasspath)
+        }
+    }
+}
+
+tasks.register<ShadowJar>("shadowTcnativeJar") {
+    archiveClassifier.set("tcnative")
+    from(sourceSets.main.get().output)
+    configurations = listOf(tcnativeImageClasspath)
+    manifest {
+        attributes.put("Main-Class", application.mainClass.get())
+    }
+    exclude("META-INF/INDEX.LIST", "META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "module-info.class")
+}
+
+tasks.register("nativeImages") {
+    dependsOn(tasks.withType<BuildNativeImageTask>())
+}
+
+tasks.register("shadowJars") {
+    dependsOn(tasks.withType<ShadowJar>())
+}
+
+tasks.register("allVariants") {
+    dependsOn("nativeImages", "shadowJars")
 }


### PR DESCRIPTION
This commit updates the project layout so that with a single test project we can generate all 4 variants to be benchmarked:

   - `shadowJar` for the JVM main jar
   - `shadowTcnativeJar` for the tcnative jar
   - `nativeCompile` for the native version
   - `nativeTcnativeCompile` for the native version with tcnative

In addition, the `allVariants` task will build all of these.